### PR TITLE
Match default array RuboCop Rails style in routes

### DIFF
--- a/lib/generators/active_registration/install_generator.rb
+++ b/lib/generators/active_registration/install_generator.rb
@@ -23,7 +23,7 @@ module ActiveRegistration
       # TODO implement edit and update in the future
       # resource :registration, only: [:new, :create, :edit, :update] do
       route <<~ROUTE
-        resource :registration, only: [:new, :create] do
+        resource :registration, only: [ :new, :create ] do
           get :confirm, on: :collection
         end
       ROUTE


### PR DESCRIPTION
A small tweak so that it matches the default [rubocop-rails-omakase](https://github.com/rails/rubocop-rails-omakase/blob/main/rubocop.yml) style for new apps.