### PR TITLE
Run RuboCop on generated files

### DIFF
--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -38,6 +38,9 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/user.rb" do |content|
       assert_includes content, "include ActiveRegistration::UserExtensions"
     end
+
+    rubocop_result = system('bundle exec rubocop "**/*.rb"')
+    assert rubocop_result, "RuboCop issues found within the generated files"
   end
 
   private


### PR DESCRIPTION
This would help catch issues such as https://github.com/Salanoid/active_registration/pull/1